### PR TITLE
feat(spoke): back off fruitless worker recoveries and signal terminal failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tab-election",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tab-election",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "license": "MIT",
       "devDependencies": {
         "http-server": "^14.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tab-election",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Provides leadership election and communication in the browser across tabs and workers using the Locks API and BroadcastChannel.",
   "main": "dist/tab.js",
   "module": "dist/tab.js",

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -605,6 +605,10 @@ export class Spoke {
       // A worker whose module script fails to fetch or parse (a deploy purged
       // the old hashed asset, the network is down, a syntax error) never runs
       // a line of code — this 'error' event is the only signal it exists.
+      // Best-effort: whether load/MIME failures fire a usable 'error' event
+      // (or any message) is browser-dependent. Detection here is only a
+      // fast path — a silent boot failure still lands in the backed-off
+      // heartbeat-gap recovery, which is the actual thrash guard.
       worker.addEventListener('error', ((e: Event) => {
         if (worker !== this.worker) return;
         const message = (e as ErrorEvent).message;

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -181,14 +181,40 @@ export interface SpokeOptions {
   useSharedWorker?: boolean;
   /** How long a service call waits for a return before rejecting with `Error('Call timed out')`. Default 30s. */
   callTimeout?: number;
+  /** Minimum delay between fruitless worker recoveries (ms). Doubles per fruitless recovery. Default 10s. */
+  recoveryBackoffMinMs?: number;
+  /** Ceiling for the recovery backoff (ms). Default 5 minutes. */
+  recoveryBackoffMaxMs?: number;
+  /** Fruitless recoveries (no heartbeat between them) before `onRecoveryFailed` fires. Default 5. */
+  maxFruitlessRecoveries?: number;
 }
 
-/** Why a spoke recovered its hub worker. */
-export type RecoveryReason = 'heartbeat' | 'call-stall';
+/**
+ * Why a spoke recovered its hub worker: heartbeats stopped ('heartbeat'),
+ * service calls kept timing out while heartbeats continued ('call-stall'), or
+ * the worker fired an 'error' event before ever producing a heartbeat
+ * ('boot-failure' — e.g. its module script failed to fetch or parse).
+ */
+export type RecoveryReason = 'heartbeat' | 'call-stall' | 'boot-failure';
 
 export interface RecoveryEvent {
   reason: RecoveryReason;
   attempt: number;
+}
+
+/**
+ * Fired once per wedge episode when repeated worker recoveries never produce
+ * a heartbeat — the worker is not coming back on its own (the classic cause: a
+ * deploy purged the old hashed worker script, so every respawn re-fetches a
+ * URL that no longer serves JavaScript). The app should escalate: surface the
+ * failure and, when it cannot lose user data, reload onto fresh assets.
+ * Recovery attempts continue at the backoff ceiling after this fires.
+ */
+export interface RecoveryFailedEvent {
+  /** Consecutive recoveries without a single heartbeat in between. */
+  attempts: number;
+  /** Message from the last worker 'error' event, when one fired (e.g. a failed script fetch). */
+  lastError?: string;
 }
 
 /**
@@ -492,6 +518,19 @@ export class Spoke {
   protected _lastHeartbeat = 0;
   protected _consecutiveCallTimeouts = 0;
   protected onRecoveryListeners = new Set<EventListener<RecoveryEvent>>();
+  protected onRecoveryFailedListeners = new Set<EventListener<RecoveryFailedEvent>>();
+  /** When the last worker recovery ran — the base the backoff gate measures from. */
+  protected _lastRecoverAt = 0;
+  /** Recoveries since the last heartbeat; >0 means the episode is so far fruitless. */
+  protected _recoveriesSinceHeartbeat = 0;
+  /** Whether any heartbeat has arrived since the current worker spawned. */
+  protected _heartbeatSinceSpawn = false;
+  /** Message from the newest worker 'error' event this episode, for RecoveryFailedEvent. */
+  protected _lastWorkerError?: string;
+  protected _recoveryFailedFired = false;
+  protected _recoveryBackoffMinMs: number;
+  protected _recoveryBackoffMaxMs: number;
+  protected _maxFruitlessRecoveries: number;
 
   readonly name: string;
   readonly version?: string;
@@ -512,6 +551,9 @@ export class Spoke {
   constructor(options: SpokeOptions) {
     this.name = options.name || 'default';
     this.version = options.version || '0.0.0';
+    this._recoveryBackoffMinMs = options.recoveryBackoffMinMs ?? 10_000;
+    this._recoveryBackoffMaxMs = options.recoveryBackoffMaxMs ?? 300_000;
+    this._maxFruitlessRecoveries = options.maxFruitlessRecoveries ?? 5;
     this.tab = new Tab(`hub/${this.name}/${this.version}`, { callTimeout: options.callTimeout });
     this.tab.addEventListener('state', event => {
       this.onStateListeners.forEach(listener => listener(event.data));
@@ -534,20 +576,46 @@ export class Spoke {
       }
     }
 
-    // Listen for leadership changes from the worker (regular Worker via postMessage,
-    // in-tab Hub via EventTarget). SharedWorker is excluded since the spoke doesn't own it.
-    if (!(isSharedWorker(this.worker))) {
-      this.worker.addEventListener('message', ((e: MessageEvent) => {
+    this._attachWorkerListeners(this.worker);
+
+    // Monitor heartbeats from the hub for worker recovery
+    if (this._workerUrl) {
+      this._startHeartbeatMonitoring();
+    }
+  }
+
+  /**
+   * Attach the per-worker listeners: leadership changes (regular Worker via
+   * postMessage, in-tab Hub via EventTarget — SharedWorker is excluded since
+   * the spoke doesn't own it) and worker 'error' (real workers only). Called
+   * for the initial worker and again for every replacement `_recover` spawns;
+   * each listener ignores events once its worker has been replaced.
+   */
+  protected _attachWorkerListeners(worker: Worker | SharedWorker | Hub): void {
+    if (!isSharedWorker(worker)) {
+      worker.addEventListener('message', ((e: MessageEvent) => {
+        if (worker !== this.worker) return;
         if (e.data?.type === 'tab-election:leadership') {
           this._isLeader = e.data.isLeader;
           this.onLeaderChangeListeners.forEach(l => l(e.data.isLeader));
         }
       }) as EventListener);
     }
-
-    // Monitor heartbeats from the hub for worker recovery
-    if (this._workerUrl) {
-      this._startHeartbeatMonitoring();
+    if (isDedicatedWorker(worker) || isSharedWorker(worker)) {
+      // A worker whose module script fails to fetch or parse (a deploy purged
+      // the old hashed asset, the network is down, a syntax error) never runs
+      // a line of code — this 'error' event is the only signal it exists.
+      worker.addEventListener('error', ((e: Event) => {
+        if (worker !== this.worker) return;
+        const message = (e as ErrorEvent).message;
+        this._lastWorkerError = typeof message === 'string' && message ? message : 'worker error event';
+        // Only treat it as a boot failure while no heartbeat has arrived since
+        // this worker spawned — a runtime error in a live hub is not fatal
+        // (call-stall detection owns actual wedges).
+        if (!this._heartbeatSinceSpawn && this._workerUrl) {
+          this._initiateRecovery('boot-failure');
+        }
+      }) as EventListener);
     }
   }
 
@@ -608,6 +676,23 @@ export class Spoke {
   onRecovery(listener: EventListener<RecoveryEvent>): UnsubscribeFunction {
     this.onRecoveryListeners.add(listener);
     return () => this.onRecoveryListeners.delete(listener);
+  }
+
+  /**
+   * Listen for the terminal recovery signal: repeated worker recoveries have
+   * produced no heartbeat, so the worker is not coming back on its own (see
+   * {@link RecoveryFailedEvent}). Fires at most once per wedge episode — a
+   * later heartbeat closes the episode and re-arms it. The spoke keeps
+   * retrying at the backoff ceiling after it fires; the app should escalate
+   * (surface the failure, and reload onto fresh assets when that cannot lose
+   * user data).
+   *
+   * @param listener - Function to call when recovery is declared failed
+   * @returns A function to unsubscribe the listener
+   */
+  onRecoveryFailed(listener: EventListener<RecoveryFailedEvent>): UnsubscribeFunction {
+    this.onRecoveryFailedListeners.add(listener);
+    return () => this.onRecoveryFailedListeners.delete(listener);
   }
 
   /**
@@ -705,6 +790,11 @@ export class Spoke {
     this.tab.addEventListener('message', (e: MessageEvent) => {
       if (e.data?.type === 'tab-election:heartbeat') {
         this._lastHeartbeat = Date.now();
+        this._heartbeatSinceSpawn = true;
+        // A heartbeat means a live hub — whatever episode was running is over.
+        this._recoveriesSinceHeartbeat = 0;
+        this._recoveryFailedFired = false;
+        this._lastWorkerError = undefined;
       } else if (e.data?.type === 'tab-election:recover') {
         if (isSharedWorker(this.worker)) {
           // SharedWorker recovery broadcasts — all spokes must switch together
@@ -742,7 +832,12 @@ export class Spoke {
       this.tab.send({ type: 'tab-election:recover', attempt, reason });
       this._recover(attempt, reason);
     } else if (isDedicatedWorker(this.worker)) {
-      if (this._isLeader) {
+      if (this._isLeader || !this._heartbeatSinceSpawn) {
+        // Leaders own the hung worker and recover it directly. A spoke whose
+        // worker has never been alive since it spawned (no heartbeat — e.g.
+        // its script failed to load) also recovers its own: that worker never
+        // claimed leadership so there is no owner to broadcast to, and
+        // terminating it cannot disturb a live leader.
         this._recover(attempt, reason);
       } else {
         this.tab.send({ type: 'tab-election:recover', attempt, reason });
@@ -766,10 +861,30 @@ export class Spoke {
     }
   }
 
+  /**
+   * Delay required before the next respawn: nothing for the first recovery of
+   * an episode, then doubling per fruitless recovery (one that produced no
+   * heartbeat) up to the ceiling.
+   */
+  protected _recoveryBackoffMs(): number {
+    if (this._recoveriesSinceHeartbeat === 0) return 0;
+    return Math.min(this._recoveryBackoffMinMs * 2 ** (this._recoveriesSinceHeartbeat - 1), this._recoveryBackoffMaxMs);
+  }
+
   protected _recover(attempt: number, reason: RecoveryReason = 'heartbeat'): void {
     if (attempt <= this._recoveryAttempt) return;
+    // Pace respawns. A worker that can never come back — its script URL now
+    // serves the SPA fallback because a newer deploy purged the old hashed
+    // asset — would otherwise be terminated and re-fetched on every heartbeat
+    // gap: an infinite ~6/min thrash observed fleet-wide in production
+    // (2026-07-14). Skipping leaves `_recoveryAttempt` unchanged so the same
+    // attempt re-qualifies once the backoff window has passed.
+    if (Date.now() - this._lastRecoverAt < this._recoveryBackoffMs()) return;
     this._recoveryAttempt = attempt;
+    this._lastRecoverAt = Date.now();
+    this._recoveriesSinceHeartbeat++;
     this._consecutiveCallTimeouts = 0;
+    this._heartbeatSinceSpawn = false;
     this.onRecoveryListeners.forEach(l => l({ reason, attempt }));
 
     if (isSharedWorker(this.worker)) {
@@ -779,19 +894,21 @@ export class Spoke {
       // The Hub parses the recovery suffix and uses steal:true on the lock.
       const name = `${this.name}:${this.version}:recover-${attempt}`;
       this.worker = new SharedWorker(this._workerUrl!, { type: 'module', name });
+      this._attachWorkerListeners(this.worker);
     } else if (isDedicatedWorker(this.worker)) {
       this.worker.terminate();
       // New Worker — lock was released by terminate, another tab's worker
       // or this new one will take leadership naturally.
       const name = `${this.name}:${this.version}`;
       this.worker = new Worker(this._workerUrl!, { type: 'module', name });
-      // Re-attach leadership change listener on the new worker
-      this.worker.addEventListener('message', ((e: MessageEvent) => {
-        if (e.data?.type === 'tab-election:leadership') {
-          this._isLeader = e.data.isLeader;
-          this.onLeaderChangeListeners.forEach(l => l(e.data.isLeader));
-        }
-      }) as EventListener);
+      this._attachWorkerListeners(this.worker);
+    }
+
+    if (this._recoveriesSinceHeartbeat > this._maxFruitlessRecoveries && !this._recoveryFailedFired) {
+      this._recoveryFailedFired = true;
+      const event: RecoveryFailedEvent = { attempts: this._recoveriesSinceHeartbeat };
+      if (this._lastWorkerError !== undefined) event.lastError = this._lastWorkerError;
+      this.onRecoveryFailedListeners.forEach(l => l(event));
     }
   }
 }

--- a/tests/spoke.spec.ts
+++ b/tests/spoke.spec.ts
@@ -28,11 +28,33 @@ class FakeWorker extends EventTarget {
   postMessage() {}
 }
 
+class FakeSharedWorkerPort {
+  closed = false;
+  close() {
+    this.closed = true;
+  }
+  start() {}
+  postMessage() {}
+}
+
+class FakeSharedWorker extends EventTarget {
+  static instances: FakeSharedWorker[] = [];
+  port = new FakeSharedWorkerPort();
+  constructor(
+    public url: string,
+    public options?: { type?: string; name?: string },
+  ) {
+    super();
+    FakeSharedWorker.instances.push(this);
+  }
+}
+
 let spokes: Spoke[] = [];
 
 beforeEach(() => {
   installLocksFake();
   FakeWorker.instances = [];
+  FakeSharedWorker.instances = [];
   (globalThis as any).Worker = FakeWorker;
   delete (globalThis as any).SharedWorker;
 });
@@ -162,6 +184,23 @@ describe('Spoke boot-failure recovery and backoff', () => {
 
     expect(first.terminated).toBe(true);
     expect(FakeWorker.instances).toHaveLength(2);
+    expect(recoveries).toEqual([{ reason: 'boot-failure', attempt: 1 }]);
+  });
+
+  it('recovers a never-booted SharedWorker too: port closed, replacement carries the recovery suffix', () => {
+    (globalThis as any).SharedWorker = FakeSharedWorker;
+    const spoke = makeSpoke('boot-fail-shared', { useSharedWorker: true });
+    const recoveries: RecoveryEvent[] = [];
+    spoke.onRecovery(e => recoveries.push(e));
+
+    const first = FakeSharedWorker.instances[0];
+    first.dispatchEvent(new FakeErrorEvent('Failed to fetch worker script'));
+
+    expect(first.port.closed).toBe(true);
+    expect(FakeSharedWorker.instances).toHaveLength(2);
+    // The recovery suffix makes the browser mint a fresh SharedWorker process;
+    // the Hub parses it and takes the leadership lock with steal:true.
+    expect(FakeSharedWorker.instances[1].options?.name).toBe('boot-fail-shared:0.0.0:recover-1');
     expect(recoveries).toEqual([{ reason: 'boot-failure', attempt: 1 }]);
   });
 

--- a/tests/spoke.spec.ts
+++ b/tests/spoke.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { installLocksFake } from './locks-fake';
-import { Spoke, type RecoveryEvent } from '../src/hub';
+import { Spoke, type RecoveryEvent, type RecoveryFailedEvent, type SpokeOptions } from '../src/hub';
+import { Tab } from '../src/tab';
 
 /**
  * Pins the SPOKE-2 fix: a hub that keeps heartbeating (its heartbeat interval
@@ -44,11 +45,11 @@ afterEach(() => {
   spokes = [];
 });
 
-function makeSpoke(name: string): Spoke {
+function makeSpoke(name: string, options?: Partial<SpokeOptions>): Spoke {
   // No hub ever acquires the leadership lock in these tests, so every service
   // call queues and rejects at callTimeout — simulating a wedged hub whose
   // calls never return (heartbeats are irrelevant to the stall detector).
-  const spoke = new Spoke({ workerUrl: 'fake-hub.js', name, callTimeout: 150 });
+  const spoke = new Spoke({ workerUrl: 'fake-hub.js', name, callTimeout: 150, ...options });
   spokes.push(spoke);
   return spoke;
 }
@@ -56,6 +57,25 @@ function makeSpoke(name: string): Spoke {
 function setLeader(spoke: Spoke, isLeader: boolean) {
   const worker = (spoke as any).worker as FakeWorker;
   worker.dispatchEvent(new MessageEvent('message', { data: { type: 'tab-election:leadership', isLeader } }));
+}
+
+function currentWorker(spoke: Spoke): FakeWorker {
+  return (spoke as any).worker as FakeWorker;
+}
+
+// Node has no ErrorEvent global; the spoke only reads `.message` off the event.
+class FakeErrorEvent extends Event {
+  constructor(public message: string) {
+    super('error');
+  }
+}
+
+/** Deliver a hub heartbeat over the shared tab channel, as a live leader would. */
+async function sendHeartbeat(name: string) {
+  const hubTab = new Tab(`hub/${name}/0.0.0`);
+  hubTab.send({ type: 'tab-election:heartbeat' });
+  await wait(20); // broadcast delivery
+  hubTab.close();
 }
 
 describe('Spoke call-stall recovery', () => {
@@ -81,6 +101,10 @@ describe('Spoke call-stall recovery', () => {
     setLeader(owner, true);
     const observer = makeSpoke('stall-remote');
     setLeader(observer, false);
+    // A heartbeat proves a live leader exists somewhere: without one the
+    // observer would treat its own never-alive worker as the problem and
+    // recover it directly instead of deferring to the owner.
+    await sendHeartbeat('stall-remote');
     const ownerRecoveries: RecoveryEvent[] = [];
     owner.onRecovery(e => ownerRecoveries.push(e));
 
@@ -116,5 +140,94 @@ describe('Spoke call-stall recovery', () => {
     const first = FakeWorker.instances[0];
     await expect(svc.doWork()).rejects.toThrow('Call timed out');
     expect(first.terminated).toBe(false); // counter was reset — this is timeout #1, not #2
+  });
+});
+
+/**
+ * Pins the respawn-thrash fix (2026-07-14): a worker whose script can never
+ * load again (a deploy purged the old hashed asset, so the URL serves the SPA
+ * fallback) used to be terminated and re-fetched on every heartbeat gap —
+ * an infinite ~6/min loop that left sync dead for hours. Boot failures now
+ * recover immediately but back off exponentially while fruitless, and a
+ * terminal `onRecoveryFailed` tells the app to escalate.
+ */
+describe('Spoke boot-failure recovery and backoff', () => {
+  it('recovers its own worker on an error before any heartbeat, even when not leader', async () => {
+    const spoke = makeSpoke('boot-fail');
+    const recoveries: RecoveryEvent[] = [];
+    spoke.onRecovery(e => recoveries.push(e));
+
+    const first = currentWorker(spoke);
+    first.dispatchEvent(new FakeErrorEvent('Failed to fetch worker script'));
+
+    expect(first.terminated).toBe(true);
+    expect(FakeWorker.instances).toHaveLength(2);
+    expect(recoveries).toEqual([{ reason: 'boot-failure', attempt: 1 }]);
+  });
+
+  it('ignores worker errors once a heartbeat has proven the hub alive', async () => {
+    const spoke = makeSpoke('boot-runtime-error');
+    await sendHeartbeat('boot-runtime-error');
+
+    currentWorker(spoke).dispatchEvent(new FakeErrorEvent('some runtime error'));
+
+    expect(FakeWorker.instances).toHaveLength(1);
+    expect(currentWorker(spoke).terminated).toBe(false);
+  });
+
+  it('backs off between fruitless recoveries instead of thrashing', async () => {
+    const spoke = makeSpoke('boot-backoff', { recoveryBackoffMinMs: 80, recoveryBackoffMaxMs: 1000 });
+
+    currentWorker(spoke).dispatchEvent(new FakeErrorEvent('gone')); // recovery 1: immediate
+    expect(FakeWorker.instances).toHaveLength(2);
+
+    // Still inside the 80ms window — the replacement's failure must NOT respawn yet.
+    currentWorker(spoke).dispatchEvent(new FakeErrorEvent('gone'));
+    expect(FakeWorker.instances).toHaveLength(2);
+
+    await wait(100);
+    currentWorker(spoke).dispatchEvent(new FakeErrorEvent('gone')); // window passed
+    expect(FakeWorker.instances).toHaveLength(3);
+  });
+
+  it('fires onRecoveryFailed once after repeated fruitless recoveries, with the last error', async () => {
+    const spoke = makeSpoke('boot-terminal', { recoveryBackoffMinMs: 1, recoveryBackoffMaxMs: 4, maxFruitlessRecoveries: 2 });
+    const failures: RecoveryFailedEvent[] = [];
+    spoke.onRecoveryFailed(e => failures.push(e));
+
+    for (let i = 0; i < 4; i++) {
+      currentWorker(spoke).dispatchEvent(new FakeErrorEvent(`load failed #${i + 1}`));
+      await wait(10);
+    }
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0].attempts).toBe(3); // fired on the first recovery past the max
+    expect(failures[0].lastError).toBe('load failed #3');
+  });
+
+  it('a heartbeat closes the episode: backoff resets and onRecoveryFailed re-arms', async () => {
+    const spoke = makeSpoke('boot-reset', { recoveryBackoffMinMs: 60_000, maxFruitlessRecoveries: 2 });
+    setLeader(spoke, true);
+    const failures: RecoveryFailedEvent[] = [];
+    spoke.onRecoveryFailed(e => failures.push(e));
+
+    currentWorker(spoke).dispatchEvent(new FakeErrorEvent('gone'));
+    expect(FakeWorker.instances).toHaveLength(2);
+    // Fruitless once — the next failure sits behind a 60s backoff…
+    currentWorker(spoke).dispatchEvent(new FakeErrorEvent('gone'));
+    expect(FakeWorker.instances).toHaveLength(2);
+
+    // …until a heartbeat proves a hub came alive, closing the episode. (A
+    // worker error after a heartbeat is a runtime error, not a boot failure,
+    // so the next episode is driven through call-stall detection instead.)
+    await sendHeartbeat('boot-reset');
+    expect((spoke as any)._recoveriesSinceHeartbeat).toBe(0);
+
+    const svc = spoke.getService<any>('svc');
+    await expect(svc.doWork()).rejects.toThrow('Call timed out');
+    await expect(svc.doWork()).rejects.toThrow('Call timed out');
+    // Recovery ran immediately again — new episode, no backoff, no terminal.
+    expect(FakeWorker.instances).toHaveLength(3);
+    expect(failures).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## TL;DR

A hub worker that can never come back — the classic cause: a deploy purged the old hashed worker asset, so its URL now serves the SPA fallback — used to be terminated and re-fetched **every 5–10s forever**. Observed fleet-wide in Dabble production on 2026-07-14: users stuck in a ~6/min respawn loop for 4–6 hours with sync completely dead (thousands of `hub_watchdog_recover` events per user, the flapping `dw3: sync-error spike` alert). This PR paces recoveries, detects boot failures, and adds a terminal `onRecoveryFailed` signal so the app can escalate.

## The failure mode

1. Any transient stall triggers a recovery: `_recover()` terminates the worker and does `new Worker(workerUrl)` — a fresh network/SW fetch of a **hashed asset baked into the (now stale) page bundle**.
2. Newer deploys purged that asset; the URL serves `index.html`. The module worker dies on parse — its `error` event had no listener, so the failure was invisible.
3. The heartbeat monitor compares against the **old** worker's `_lastHeartbeat`, so it re-fires recovery every 5–10s. No backoff, no cap, no boot detection → infinite thrash, permanent sync death for the tab's lifetime.

## Changes

- **Worker `error` events are now observed.** Before any heartbeat since spawn they trigger an immediate `'boot-failure'` recovery (new `RecoveryReason`), and the message is carried into the terminal event. A never-booted worker was previously invisible (it also never claimed leadership, so `_lastHeartbeat > 0` gating could leave it unrecovered forever after a fresh page load).
- **Exponential backoff on fruitless recoveries.** Recoveries with no heartbeat in between back off `recoveryBackoffMinMs` (10s) doubling to `recoveryBackoffMaxMs` (5min). Any heartbeat closes the episode and resets the backoff. All trigger paths (heartbeat-gap, call-stall, boot-failure, recover broadcasts) funnel through the same pacing gate in `_recover`; a paced-out attempt leaves `_recoveryAttempt` unchanged so it re-qualifies once the window passes.
- **Self-recovery for never-alive workers.** A spoke whose worker has produced no heartbeat since spawn recovers it directly instead of broadcasting into the void — no owner exists to act on the broadcast (a never-booted worker holds no leadership), and terminating it cannot disturb a live leader.
- **Terminal signal.** After `maxFruitlessRecoveries` (5) consecutive fruitless recoveries, `onRecoveryFailed` fires once per episode with `{ attempts, lastError }`. Retries continue at the backoff ceiling. The app should escalate — Dabble reloads onto fresh assets when that cannot lose user data (dabblewriter/dabble-writer-3.0 follow-up PR).

With defaults, a dead-forever worker now costs ~7 respawn attempts in the first 5 minutes (then one per 5min) instead of ~360/hour, and the app learns about it ~5 minutes in instead of never.

## Testing

- 5 new specs pin boot-failure recovery, the runtime-error exclusion (a worker error after a heartbeat is NOT a boot failure), backoff gating, the once-per-episode terminal event with `lastError`, and episode reset on heartbeat.
- The existing broadcast-deferral spec now delivers a heartbeat first — the realistic precondition for deferring to an owner (without one, the observer's own worker has never been alive and is now correctly self-recovered).
- 13/13 tests green; `tsc` clean.

## Version

4.4.0 → 4.5.0 (additive API). dabble-writer-3.0 bumps to `^4.5.0` in the companion PR — needs an npm publish once this merges.