### PR TITLE
fix(spoke): count call timeouts per method so a write-path wedge recovers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tab-election",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tab-election",
-      "version": "4.5.0",
+      "version": "4.6.0",
       "license": "MIT",
       "devDependencies": {
         "http-server": "^14.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tab-election",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "Provides leadership election and communication in the browser across tabs and workers using the Locks API and BroadcastChannel.",
   "main": "dist/tab.js",
   "module": "dist/tab.js",

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -516,7 +516,18 @@ export class Spoke {
   protected _recoveryAttempt = 0;
   protected _heartbeatTimeout?: ReturnType<typeof setTimeout>;
   protected _lastHeartbeat = 0;
-  protected _consecutiveCallTimeouts = 0;
+  /**
+   * Consecutive `Call timed out` rejections per `namespace.method`, NOT per
+   * spoke. A hub can wedge on ONE code path while every other path stays
+   * responsive — the observed shape is a hub whose write loop has starved
+   * while its RPC dispatcher still answers cheap reads. A single spoke-wide
+   * counter cannot see that: any successful call anywhere zeroes it, and a
+   * real app is always chattering on something (presence leases, tab pings,
+   * liveness probes), so the wedged path's timeouts never accumulate and the
+   * worker is never respawned. Keying by method lets a starved path reach the
+   * threshold on its own evidence while healthy traffic flows past it.
+   */
+  protected _consecutiveCallTimeouts = new Map<string, number>();
   protected onRecoveryListeners = new Set<EventListener<RecoveryEvent>>();
   protected onRecoveryFailedListeners = new Set<EventListener<RecoveryFailedEvent>>();
   /** When the last worker recovery ran — the base the backoff gate measures from. */
@@ -742,9 +753,10 @@ export class Spoke {
           return undefined;
         }
         return async (...args: any[]) => {
+          const method = `${namespace}.${prop as string}`;
           try {
-            const result = await this.tab.call(`${namespace}.${prop as string}`, ...args);
-            this._consecutiveCallTimeouts = 0;
+            const result = await this.tab.call(method, ...args);
+            this._consecutiveCallTimeouts.delete(method);
             return result;
           } catch (e) {
             // A wedged hub keeps heartbeating (the heartbeat interval is
@@ -752,9 +764,12 @@ export class Spoke {
             // never fires — consecutive call timeouts are the liveness signal
             // for that failure mode.
             if (e instanceof Error && e.message === 'Call timed out') {
-              this._noteCallTimeout();
+              this._noteCallTimeout(method);
             } else {
-              this._consecutiveCallTimeouts = 0;
+              // The rejection came back THROUGH the hub, so this path drained —
+              // it is as much proof of liveness as a resolved call, but only
+              // for this method.
+              this._consecutiveCallTimeouts.delete(method);
             }
             throw e;
           }
@@ -853,14 +868,18 @@ export class Spoke {
     }
   }
 
-  protected _noteCallTimeout(): void {
-    this._consecutiveCallTimeouts++;
-    // Two consecutive timeouts (~2× callTimeout of unresponsiveness) marks the
-    // hub as wedged even though its heartbeat interval — which is independent
-    // of service-call drain — keeps firing. One timeout alone may just be a
-    // single slow call.
-    if (this._consecutiveCallTimeouts >= 2 && this._workerUrl) {
-      this._consecutiveCallTimeouts = 0;
+  protected _noteCallTimeout(method: string): void {
+    const timeouts = (this._consecutiveCallTimeouts.get(method) ?? 0) + 1;
+    this._consecutiveCallTimeouts.set(method, timeouts);
+    // Two consecutive timeouts (~2× callTimeout of unresponsiveness) on the
+    // SAME method marks the hub as wedged even though its heartbeat interval —
+    // which is independent of service-call drain — keeps firing. One timeout
+    // alone may just be a single slow call. The threshold is per-method
+    // because a starved path proves the wedge on its own: waiting for the
+    // whole spoke to go quiet would mean never recovering a hub that still
+    // answers everything except the one thing that matters.
+    if (timeouts >= 2 && this._workerUrl) {
+      this._consecutiveCallTimeouts.delete(method);
       this._initiateRecovery('call-stall');
     }
   }
@@ -887,7 +906,9 @@ export class Spoke {
     this._recoveryAttempt = attempt;
     this._lastRecoverAt = Date.now();
     this._recoveriesSinceHeartbeat++;
-    this._consecutiveCallTimeouts = 0;
+    // Fresh worker: every path starts from a clean slate, not just the one
+    // whose timeouts triggered this recovery.
+    this._consecutiveCallTimeouts.clear();
     this._heartbeatSinceSpawn = false;
     this.onRecoveryListeners.forEach(l => l({ reason, attempt }));
 

--- a/tests/spoke.spec.ts
+++ b/tests/spoke.spec.ts
@@ -142,14 +142,13 @@ describe('Spoke call-stall recovery', () => {
     expect(ownerRecoveries).toEqual([{ reason: 'call-stall', attempt: 1 }]);
   });
 
-  it('a successful call resets the stall counter', async () => {
+  it('a successful call resets the stall counter for that method', async () => {
     const spoke = makeSpoke('stall-reset');
     setLeader(spoke, true);
     const svc = spoke.getService<any>('svc');
 
     await expect(svc.doWork()).rejects.toThrow('Call timed out');
     // A hub comes alive and answers one call — the earlier timeout must not count anymore.
-    (spoke as any)._consecutiveCallTimeouts = (spoke as any)._consecutiveCallTimeouts; // (no-op, readability)
     const { Tab } = await import('../src/tab');
     const hubTab = new Tab('hub/stall-reset/0.0.0');
     hubTab.waitForLeadership(() => ({ svc: { doWork: async () => 'ok' } }));
@@ -162,6 +161,56 @@ describe('Spoke call-stall recovery', () => {
     const first = FakeWorker.instances[0];
     await expect(svc.doWork()).rejects.toThrow('Call timed out');
     expect(first.terminated).toBe(false); // counter was reset — this is timeout #1, not #2
+  });
+
+  /**
+   * The write-path-only wedge (DAB-684, 2026-07-15): a hub whose write loop has
+   * starved while its RPC dispatcher still answers cheap reads. A user sat
+   * wedged for 86 minutes with ZERO recoveries because the spoke-wide counter
+   * was zeroed by unrelated healthy traffic — presence leases every 20s, tab
+   * pings every 30s, liveness probes every 15s — between write timeouts ~2min
+   * apart. The starved path must reach the threshold on its own evidence.
+   */
+  it('a successful call to a DIFFERENT method does not reset the stall counter', async () => {
+    const spoke = makeSpoke('stall-per-method');
+    setLeader(spoke, true);
+    const recoveries: RecoveryEvent[] = [];
+    spoke.onRecovery(e => recoveries.push(e));
+    const svc = spoke.getService<any>('svc');
+
+    // A hub that answers `ping` but never drains `doWork` — the wedge shape.
+    // `doWork` must EXIST and hang: an absent method rejects as "Invalid API
+    // method", which comes back through the hub and counts as liveness.
+    const { Tab } = await import('../src/tab');
+    const hubTab = new Tab('hub/stall-per-method/0.0.0');
+    hubTab.waitForLeadership(() => ({
+      svc: { ping: async () => 'pong', doWork: () => new Promise<never>(() => {}) },
+    }));
+    await wait(20);
+
+    const first = FakeWorker.instances[0];
+    await expect(svc.doWork()).rejects.toThrow('Call timed out');
+    await expect(svc.ping()).resolves.toBe('pong'); // healthy traffic must not erase the evidence
+    await expect(svc.doWork()).rejects.toThrow('Call timed out');
+
+    expect(first.terminated).toBe(true);
+    expect(recoveries).toEqual([{ reason: 'call-stall', attempt: 1 }]);
+
+    hubTab.relinquishLeadership();
+    hubTab.close();
+  });
+
+  it('counts timeouts on different methods separately', async () => {
+    const spoke = makeSpoke('stall-independent');
+    setLeader(spoke, true);
+    const svc = spoke.getService<any>('svc');
+
+    const first = FakeWorker.instances[0];
+    // One timeout each on two methods is not two consecutive timeouts on either.
+    await expect(svc.doWork()).rejects.toThrow('Call timed out');
+    await expect(svc.otherWork()).rejects.toThrow('Call timed out');
+
+    expect(first.terminated).toBe(false);
   });
 });
 


### PR DESCRIPTION
## TL;DR

A hub that answers reads but eats writes could **never** be recovered. `_consecutiveCallTimeouts` was one counter for the whole spoke, so any successful call — a presence lease, a tab ping, a liveness probe — zeroed the evidence before the wedged path's timeouts could accumulate. Key it by `namespace.method` instead. Bumps 4.5.0 → **4.6.0**.

## The bug

`Spoke` needs 2 consecutive `Call timed out` rejections to fire `_initiateRecovery('call-stall')` and respawn the worker. But the counter was reset by *any* successful call on *any* namespace or method.

That works for a fully wedged hub. It cannot work for the shape actually seen in production: a hub whose **write loop has starved while its RPC dispatcher still answers cheap reads**. In dabble-writer-3.0 the app is always chattering on some other method —

| Caller | Cadence |
| --- | --- |
| `places.tabPing` | every 30s |
| presence lease renewal | every 20s while active |
| `hubLivenessWatchdog` probe (`patches.getDocStates`) | every 15s while wedged |

— while the starved writes (`patches.handleDocChange`) time out roughly 2 minutes apart. Several successes always land between any two write timeouts, so the counter never reached 2 and the worker was never respawned. The wedge was permanent for the lifetime of the tab.

Note that a per-*namespace* counter would not have fixed this either: the watchdog's probe (`getDocStates`) and the starved write (`handleDocChange`) are both the `patches` namespace. It has to be per-method.

## Production evidence (DAB-684)

Users trapped with **zero** `hub_watchdog_recover` events despite sustained wedges — 4 wedges and 3 still-wedged reports for the reporter, and another user wedged **86 minutes continuously**. Their writes timed out on every attempt (8 for 8, each paired with a journal-kept entry within ~4ms) while the hub answered everything else.

This also explains the loose end left open in DAB-649: *"the worker respawned only once all night."* Same mechanism.

## The change

- `_consecutiveCallTimeouts` becomes a `Map<string, number>` keyed by `namespace.method`.
- A resolved call, or a rejection that came back *through* the hub (proof that path drained), clears only that method's count.
- `_noteCallTimeout(method)` takes the method; the threshold of 2 is now per-method.
- `_recover()` clears every path's count — a fresh worker starts clean.

Threshold, backoff, boot-failure detection, and `onRecoveryFailed` are all untouched.

## Tests

16/16 green. Two new tests, both verified to **fail on `master`** and pass here:

- `a successful call to a DIFFERENT method does not reset the stall counter` — a hub that answers `ping` but hangs `doWork` now gets recovered. This is the DAB-684 shape.
- `counts timeouts on different methods separately` — one timeout each on two methods is not two consecutive timeouts on either, so it must not recover.

The existing reset test is renamed to `…for that method` to say what it now pins (I also removed a stray no-op line in it).

## Scope / follow-ups

- **This makes the failure survivable, not absent.** *Why* the reporter's hub write path dies every few minutes is still unknown and needs hub/pup-side tracing on a live wedged uid — tracked on DAB-684.
- Needs a 4.6.0 publish, then a lockfile relock in dabble-writer-3.0 to pick it up. No dw3 code change is required: with per-method counters the watchdog's probe stops suppressing recovery on its own.