### PR TITLE
fix(spoke): don't recover a live hub on wake from suspension

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tab-election",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "Provides leadership election and communication in the browser across tabs and workers using the Locks API and BroadcastChannel.",
   "main": "dist/tab.js",
   "module": "dist/tab.js",

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -803,8 +803,7 @@ export class Spoke {
   }
 
   protected _startHeartbeatMonitoring(): void {
-    // Randomized timeout between 5-10s per spoke instance
-    const timeout = 5000 + Math.random() * 5000;
+    const timeout = this._heartbeatCheckIntervalMs();
 
     this.tab.addEventListener('message', (e: MessageEvent) => {
       if (e.data?.type === 'tab-election:heartbeat') {
@@ -827,15 +826,49 @@ export class Spoke {
     });
 
     const check = () => {
+      const scheduledAt = Date.now();
       this._heartbeatTimeout = setTimeout(() => {
-        // Only trigger recovery after receiving at least one heartbeat
-        if (this._lastHeartbeat > 0 && Date.now() - this._lastHeartbeat > timeout) {
+        if (this._shouldRecoverOnHeartbeatGap(scheduledAt, timeout)) {
           this._initiateRecovery('heartbeat');
         }
         check();
       }, timeout);
     };
     check();
+  }
+
+  /** Randomized 5-10s per spoke instance. Overridable so tests can run fast. */
+  protected _heartbeatCheckIntervalMs(): number {
+    return 5000 + Math.random() * 5000;
+  }
+
+  /**
+   * How much later than scheduled a heartbeat check may fire before the gap it
+   * measures is considered untrustworthy (see _shouldRecoverOnHeartbeatGap).
+   * Loose enough for ordinary main-thread jank; a suspension overshoots it by
+   * orders of magnitude.
+   */
+  protected _heartbeatLateGraceMs(): number {
+    return 2000;
+  }
+
+  /**
+   * Whether a heartbeat-gap recovery should fire for the check window that
+   * opened at `scheduledAt`. Only ever true after at least one heartbeat has
+   * been seen (boot failures have their own detection).
+   *
+   * A check timer that fired much later than scheduled means this whole
+   * context was suspended — system sleep, a backgrounded mobile tab, Safari
+   * tab suspension. The hub's clocks were frozen right along with ours, so a
+   * stale `_lastHeartbeat` proves nothing about its health; recovering on it
+   * would respawn a perfectly live hub on every wake. Skip that round and let
+   * a clean window decide: a live hub heartbeats within ~2s of resuming, and a
+   * genuinely dead one is still recovered one interval later.
+   */
+  protected _shouldRecoverOnHeartbeatGap(scheduledAt: number, timeout: number): boolean {
+    const now = Date.now();
+    if (now - scheduledAt - timeout > this._heartbeatLateGraceMs()) return false;
+    return this._lastHeartbeat > 0 && now - this._lastHeartbeat > timeout;
   }
 
   /**

--- a/tests/spoke.spec.ts
+++ b/tests/spoke.spec.ts
@@ -319,3 +319,90 @@ describe('Spoke boot-failure recovery and backoff', () => {
     expect(failures).toHaveLength(0);
   });
 });
+
+/**
+ * Pins the suspend-aware heartbeat gap check: a spoke waking from suspension
+ * (system sleep, a backgrounded mobile tab, Safari tab suspension) sees a
+ * heartbeat as stale as the sleep was long — but the hub's clocks were frozen
+ * too, so that gap proves nothing. Recovering on it respawned a perfectly
+ * live hub on every wake, ~1,600 users/day in production telemetry.
+ */
+describe('Spoke heartbeat-gap recovery', () => {
+  const TIMEOUT = 5000;
+
+  function gapCheck(spoke: Spoke, opts: { lastHeartbeatAgo: number; firedLateBy?: number }): boolean {
+    const now = Date.now();
+    (spoke as any)._lastHeartbeat = opts.lastHeartbeatAgo === Infinity ? 0 : now - opts.lastHeartbeatAgo;
+    const scheduledAt = now - TIMEOUT - (opts.firedLateBy ?? 0);
+    return (spoke as any)._shouldRecoverOnHeartbeatGap(scheduledAt, TIMEOUT);
+  }
+
+  it('recovers on a genuine gap when the check timer fired on schedule', () => {
+    const spoke = makeSpoke('gap-genuine');
+    expect(gapCheck(spoke, { lastHeartbeatAgo: TIMEOUT * 3 })).toBe(true);
+  });
+
+  it('tolerates ordinary timer jank within the grace window', () => {
+    const spoke = makeSpoke('gap-jank');
+    expect(gapCheck(spoke, { lastHeartbeatAgo: TIMEOUT * 3, firedLateBy: 500 })).toBe(true);
+  });
+
+  it('stays quiet while heartbeats are fresh', () => {
+    const spoke = makeSpoke('gap-fresh');
+    expect(gapCheck(spoke, { lastHeartbeatAgo: 1000 })).toBe(false);
+  });
+
+  it('never fires before the first heartbeat (boot failures own that path)', () => {
+    const spoke = makeSpoke('gap-boot');
+    expect(gapCheck(spoke, { lastHeartbeatAgo: Infinity })).toBe(false);
+  });
+
+  it('skips the check that wakes from suspension instead of recovering a live hub', () => {
+    const spoke = makeSpoke('gap-suspend');
+    const twoHours = 2 * 60 * 60 * 1000;
+    expect(gapCheck(spoke, { lastHeartbeatAgo: twoHours, firedLateBy: twoHours })).toBe(false);
+  });
+
+  class FastHeartbeatSpoke extends Spoke {
+    protected _heartbeatCheckIntervalMs(): number {
+      return 60;
+    }
+  }
+
+  function makeFastSpoke(name: string): Spoke {
+    const spoke = new FastHeartbeatSpoke({ workerUrl: 'fake-hub.js', name, callTimeout: 150 });
+    spokes.push(spoke);
+    return spoke;
+  }
+
+  it('still recovers a hub that genuinely stops heartbeating', async () => {
+    const spoke = makeFastSpoke('gap-dead');
+    setLeader(spoke, true);
+    const recoveries: RecoveryEvent[] = [];
+    spoke.onRecovery(e => recoveries.push(e));
+
+    await sendHeartbeat('gap-dead');
+    // Silence. The next on-schedule check sees the gap and respawns the worker.
+    await wait(250);
+
+    expect(recoveries.length).toBeGreaterThanOrEqual(1);
+    expect(recoveries[0].reason).toBe('heartbeat');
+    expect(FakeWorker.instances.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('does not recover while heartbeats keep flowing', async () => {
+    const spoke = makeFastSpoke('gap-alive');
+    setLeader(spoke, true);
+    const recoveries: RecoveryEvent[] = [];
+    spoke.onRecovery(e => recoveries.push(e));
+
+    const hubTab = new Tab('hub/gap-alive/0.0.0');
+    const beat = setInterval(() => hubTab.send({ type: 'tab-election:heartbeat' }), 15);
+    await wait(300);
+    clearInterval(beat);
+    hubTab.close();
+
+    expect(recoveries).toEqual([]);
+    expect(FakeWorker.instances).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
**TL;DR:** ~1,600 users/day of "hub worker recovered" events are mostly false positives: a spoke waking from system sleep / mobile backgrounding / Safari tab suspension compares wall-clock time against a pre-sleep heartbeat and respawns a perfectly live hub on every wake. Detect suspension by the check timer itself firing late and give the hub one clean window to prove itself. v4.6.0 → 4.6.1.

## The bug

The heartbeat monitor's check loop fires every 5–10s and recovers when `Date.now() - _lastHeartbeat > timeout`. During suspension both the spoke's timer **and the hub's 2s heartbeat interval** freeze. On wake, the spoke's overdue timer fires immediately and sees a heartbeat exactly as stale as the sleep was long — hours — and fires `_initiateRecovery('heartbeat')` before the equally-healthy worker gets its first post-resume beat out. The first recovery of an episode has zero backoff, so every laptop-lid-open or app-switch-back is a guaranteed spurious respawn: port closed, new SharedWorker (`steal: true`), IDB reopen, SSE reconnect, all hub in-memory state lost (the mechanism behind dabble-writer-3.0#1169's permanent "Unknown Device").

Production telemetry (24h, [DABBLE-WRITER-3-9R](https://dabblewriter.sentry.io/issues/DABBLE-WRITER-3-9R)) matches this signature precisely on the current 3.0.27 build:
- **86% of heartbeat recoveries are attempt 1**, ~1 per user — the "dead" hub is alive again by the next check.
- Platform mix is suspend-ranked, not usage-ranked: macOS **Safari** first, iOS second, Android third; mobile is ~37% of events. Firefox and Electron both present — environmental, not a browser bug.

## The fix

`check()` stamps when it scheduled its timer; the callback treats firing >2s later than scheduled as proof of suspension and skips that round instead of trusting the stale gap. The next window opens from *now*: a live hub heartbeats within ~2s of resuming (no recovery), a genuinely dead one is recovered one clean interval later (5–10s delay, negligible). No platform APIs, no new state beyond the stamp.

The decision is extracted to `_shouldRecoverOnHeartbeatGap()` and the interval/grace are overridable protected methods, so the regression is pinned deterministically:

- suspension (timer 2h late + heartbeat 2h stale) → **no recovery** (fails on 4.6.0's logic — verified by removing the guard)
- on-schedule timer + genuine gap → recovers, within-grace jank → still recovers
- fresh heartbeats / never-heartbeated → quiet (boot-failure owns the pre-first-beat path)
- fast-interval integration: a hub that stops beating is still respawned; one that keeps beating never is

23/23 tests, clean `tsc` build.

## Out of scope (noted for follow-up)

The call-timeout path has a milder version of the same wake noise: calls in flight during suspension all reject on resume, and two on the same method count toward `call-stall`. Left alone here — it needs two in-flight calls on one method to misfire, and the per-method counters (#12) already bound it.