### PR TITLE
Fix leadership-term and call-lifecycle leaks in Tab

### DIFF
--- a/src/tab.ts
+++ b/src/tab.ts
@@ -64,6 +64,7 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
   private _sentCalls = new Map<number, any>();
   private _callTimeout: number;
   private _closeAbort = new AbortController();
+  private _closed = false;
 
   constructor(name = 'default', options?: TabOptions) {
     super();
@@ -90,6 +91,7 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
   }
 
   hasLeader(): Promise<boolean> {
+    if (this._closed) return Promise.resolve(false);
     if (this._hasLeaderCache || this.isLeader) return Promise.resolve(true);
     if (this._hasLeaderChecking) return this._hasLeaderChecking;
 
@@ -123,8 +125,10 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
   }
   setState(state: T) {
     if (!this.isLeader) throw new Error('Only the leader can set state');
-    this._onState(state);
+    // Broadcast before storing: a state that fails to clone must not be left on this tab, where peers would never
+    // receive it and every later re-broadcast (`onLeader`, `onSendState`) would throw on it again.
     this._postMessage(To.Others, 'onState', state);
+    this._onState(state);
   }
 
   async waitForLeadership(onLeadership: OnLeadership, options?: { steal?: boolean }): Promise<boolean> {
@@ -151,6 +155,8 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
         this._api = await onLeadership(this.relinquishLeadership);
         // If leadership was relinquished during the callback, this tab never actively led: skip ready state, queued
         // call dispatch, and the onLeader broadcast, which would pose this tab's stale state as fresh leader state.
+        // Calls queued here while initializing stay in `_queuedCalls` and are forwarded to the successor by this
+        // tab's own `_onLeader`; with no successor ever elected they expire on the caller's call timeout.
         if (!relinquished) {
           this._isLeaderReady = true;
           const queued = new Set(this._queuedCalls.keys());
@@ -181,6 +187,7 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
   call<R>(name: string, ...rest: any[]): Promise<R> {
     const callNumber = ++this._callCount;
     return new Promise<R>(async (resolve, reject) => {
+      if (this._closed) return reject(new Error('Tab is closed'));
       const timeout = setTimeout(() => {
         this._callDeferreds.delete(callNumber);
         this._queuedCalls.delete(`${this._id}:${callNumber}`);
@@ -189,12 +196,19 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
       }, this._callTimeout);
       this._callDeferreds.set(callNumber, { resolve, reject, timeout, name, rest });
       const hasLeader = await this.hasLeader();
-      if (this.isLeader && this._isLeaderReady) {
-        this._onCall(this._id, callNumber, name, ...rest);
-      } else if (!this.isLeader && hasLeader) {
-        this._sendCall(callNumber, name, rest);
-      } else {
-        this._queuedCalls.set(`${this._id}:${callNumber}`, { id: this._id, callNumber, name, rest });
+      try {
+        if (this.isLeader && this._isLeaderReady) {
+          this._onCall(this._id, callNumber, name, ...rest);
+        } else if (!this.isLeader && hasLeader) {
+          this._sendCall(callNumber, name, rest);
+        } else {
+          this._queuedCalls.set(`${this._id}:${callNumber}`, { id: this._id, callNumber, name, rest });
+        }
+      } catch (e) {
+        // This runs after an await inside an async executor, so a synchronous throw (a non-cloneable argument
+        // reaching `postMessage`) would otherwise float as an unhandled rejection while the caller waited out the
+        // full call timeout. Fail it now instead.
+        this._failCall(callNumber, e);
       }
     });
   }
@@ -213,6 +227,17 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
     send();
   }
 
+  /** Settle one of this tab's own pending calls with an error, mirroring `_onReturn`'s cleanup. */
+  private _failCall(callNumber: number, error: any) {
+    const deferred = this._callDeferreds.get(callNumber);
+    if (!deferred) return;
+    clearTimeout(deferred.timeout);
+    this._callDeferreds.delete(callNumber);
+    this._queuedCalls.delete(`${this._id}:${callNumber}`);
+    this._clearSentCall(callNumber);
+    deferred.reject(error);
+  }
+
   private _clearSentCall(callNumber: number) {
     const t = this._sentCalls.get(callNumber);
     if (t !== undefined) {
@@ -226,6 +251,7 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
   }
 
   close(): void {
+    this._closed = true;
     this.relinquishLeadership();
     this._closeAbort.abort();
     this._isLeader = false;
@@ -250,8 +276,9 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
   }
 
   _postMessage(to: string | Set<string>, name: string, ...rest: any[]) {
-    // Don't send if there's no one to send to
-    if (!to || to instanceof Set && !to.size) return;
+    // Don't send if there's no one to send to, or if this tab is closed: the InvalidStateError recovery below
+    // would otherwise recreate the channel and bring a closed tab back onto it.
+    if (this._closed || !to || to instanceof Set && !to.size) return;
     const data = { to, name, rest };
     try {
       this._channel.postMessage(data);
@@ -335,9 +362,18 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
   _onLeader(state: T) {
     this._onState(state);
     const queued = new Set(this._queuedCalls.keys());
-    this._queuedCalls.forEach(({ id, callNumber, name, rest }) =>
-      this._postMessage(To.Leader, 'onCall', id, callNumber, name, ...rest)
-    );
+    // One payload that fails to clone must not abort the sweep: the remaining queued calls, the clear below, and
+    // the in-flight re-delivery after it all still have to happen.
+    this._queuedCalls.forEach(({ id, callNumber, name, rest }) => {
+      try {
+        this._postMessage(To.Leader, 'onCall', id, callNumber, name, ...rest);
+      } catch (e) {
+        // Our own call can be failed directly; a foreign one is a leftover from a leader term that never dispatched
+        // it, and its caller is resending or timing it out on its own.
+        if (id === this._id) this._failCall(callNumber, e);
+        else console.error('Failed to forward queued call', name, e);
+      }
+    });
     this._queuedCalls.clear();
     // Re-deliver calls that were IN FLIGHT to the previous leader. The old
     // leader acks `callReceived` before executing, which stops the 500ms
@@ -347,9 +383,16 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
     // leader. Note this makes delivery at-least-once across leader handoff
     // (it already was whenever a `callReceived` ack was lost): handlers whose
     // execution may have completed on the dead leader must be idempotent.
+    // The same duplication happens inside a single election: a call queued while the leader was still initializing
+    // is dispatched by that leader AND re-sent from here, because the leader's `onLeader` broadcast goes out
+    // synchronously while the queued call's `onReturn` is still awaiting the handler.
     this._callDeferreds.forEach(({ name, rest }, callNumber) => {
       if (queued.has(`${this._id}:${callNumber}`) || this._sentCalls.has(callNumber)) return;
-      this._sendCall(callNumber, name, rest);
+      try {
+        this._sendCall(callNumber, name, rest);
+      } catch (e) {
+        this._failCall(callNumber, e);
+      }
     });
   }
 }

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -52,7 +52,9 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
   private _hasLeaderChecking: Promise<boolean>;
   private _callerId: string;
   private _callDeferreds = new Map<number, Deferred>();
-  private _queuedCalls = new Map<number, { id: string; name: string; rest: any[] }>();
+  // Keyed by `${callerId}:${callNumber}` — callNumber is a per-tab counter, so on the
+  // leader (which queues calls from every tab) the number alone collides across callers.
+  private _queuedCalls = new Map<string, { id: string; callNumber: number; name: string; rest: any[] }>();
   private _channel: BroadcastChannel;
   private _isLeader = false;
   private _isLeaderReady = false;
@@ -152,14 +154,14 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
         if (!relinquished) {
           this._isLeaderReady = true;
           const queued = new Set(this._queuedCalls.keys());
-          this._queuedCalls.forEach(({ id, name, rest }, callNumber) => this._onCall(id, callNumber, name, ...rest));
+          this._queuedCalls.forEach(({ id, callNumber, name, rest }) => this._onCall(id, callNumber, name, ...rest));
           this._queuedCalls.clear();
           // Re-deliver this tab's own calls that were in flight to the previous
           // leader when it died — we are the leader now, so dispatch them to
           // ourselves (see the matching re-delivery for non-leader tabs in
           // `_onLeader`; the same at-least-once caveat applies).
           this._callDeferreds.forEach(({ name, rest }, callNumber) => {
-            if (queued.has(callNumber)) return;
+            if (queued.has(`${this._id}:${callNumber}`)) return;
             this._clearSentCall(callNumber);
             this._onCall(this._id, callNumber, name, ...rest);
           });
@@ -181,7 +183,7 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
     return new Promise<R>(async (resolve, reject) => {
       const timeout = setTimeout(() => {
         this._callDeferreds.delete(callNumber);
-        this._queuedCalls.delete(callNumber);
+        this._queuedCalls.delete(`${this._id}:${callNumber}`);
         this._clearSentCall(callNumber);
         reject(new Error('Call timed out'));
       }, this._callTimeout);
@@ -192,7 +194,7 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
       } else if (!this.isLeader && hasLeader) {
         this._sendCall(callNumber, name, rest);
       } else {
-        this._queuedCalls.set(callNumber, { id: this._id, name, rest });
+        this._queuedCalls.set(`${this._id}:${callNumber}`, { id: this._id, callNumber, name, rest });
       }
     });
   }
@@ -282,7 +284,7 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
     if (!this.isLeader) return;
     this._postMessage(id, 'callReceived', callNumber);
     if (!this._isLeaderReady) {
-      this._queuedCalls.set(callNumber, { id, name, rest });
+      this._queuedCalls.set(`${id}:${callNumber}`, { id, callNumber, name, rest });
       return;
     }
     try {
@@ -333,7 +335,7 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
   _onLeader(state: T) {
     this._onState(state);
     const queued = new Set(this._queuedCalls.keys());
-    this._queuedCalls.forEach(({ id, name, rest }, callNumber) =>
+    this._queuedCalls.forEach(({ id, callNumber, name, rest }) =>
       this._postMessage(To.Leader, 'onCall', id, callNumber, name, ...rest)
     );
     this._queuedCalls.clear();
@@ -346,7 +348,7 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
     // (it already was whenever a `callReceived` ack was lost): handlers whose
     // execution may have completed on the dead leader must be idempotent.
     this._callDeferreds.forEach(({ name, rest }, callNumber) => {
-      if (queued.has(callNumber) || this._sentCalls.has(callNumber)) return;
+      if (queued.has(`${this._id}:${callNumber}`) || this._sentCalls.has(callNumber)) return;
       this._sendCall(callNumber, name, rest);
     });
   }

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -61,6 +61,7 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
   private _api: any;
   private _sentCalls = new Map<number, any>();
   private _callTimeout: number;
+  private _closeAbort = new AbortController();
 
   constructor(name = 'default', options?: TabOptions) {
     super();
@@ -102,8 +103,10 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
       // workaround to make sure the winner runs first.
       hasLeader = await check();
       this._hasLeaderCache = hasLeader;
-      // wait to know when there is no longer a leader
-      navigator.locks.request(`tab-${this._name}`, () => this._hasLeaderCache = false);
+      // wait to know when there is no longer a leader; aborted on close so a closed tab doesn't linger in the queue
+      navigator.locks
+        .request(`tab-${this._name}`, { signal: this._closeAbort.signal }, () => this._hasLeaderCache = false)
+        .catch(() => {});
       this._hasLeaderChecking = null;
       return hasLeader;
     });
@@ -135,27 +138,39 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
       return await navigator.locks.request(`tab-${this._name}`, lockOptions, async lock => {
         this._isLeader = true;
         // Never resolve until relinquishLeadership is called
-        const keepLockPromise = new Promise<boolean>(resolve => (this.relinquishLeadership = () => resolve(true)));
+        let relinquished = false;
+        const keepLockPromise = new Promise<boolean>(
+          resolve =>
+            (this.relinquishLeadership = () => {
+              relinquished = true;
+              resolve(true);
+            })
+        );
         this._api = await onLeadership(this.relinquishLeadership);
-        this._isLeaderReady = true;
-        const queued = new Set(this._queuedCalls.keys());
-        this._queuedCalls.forEach(({ id, name, rest }, callNumber) => this._onCall(id, callNumber, name, ...rest));
-        this._queuedCalls.clear();
-        // Re-deliver this tab's own calls that were in flight to the previous
-        // leader when it died — we are the leader now, so dispatch them to
-        // ourselves (see the matching re-delivery for non-leader tabs in
-        // `_onLeader`; the same at-least-once caveat applies).
-        this._callDeferreds.forEach(({ name, rest }, callNumber) => {
-          if (queued.has(callNumber)) return;
-          this._clearSentCall(callNumber);
-          this._onCall(this._id, callNumber, name, ...rest);
-        });
-        this.dispatchEvent(new Event('leadershipchange'));
-        this._postMessage(To.Others, 'onLeader', this._state);
+        // If leadership was relinquished during the callback, this tab never actively led: skip ready state, queued
+        // call dispatch, and the onLeader broadcast, which would pose this tab's stale state as fresh leader state.
+        if (!relinquished) {
+          this._isLeaderReady = true;
+          const queued = new Set(this._queuedCalls.keys());
+          this._queuedCalls.forEach(({ id, name, rest }, callNumber) => this._onCall(id, callNumber, name, ...rest));
+          this._queuedCalls.clear();
+          // Re-deliver this tab's own calls that were in flight to the previous
+          // leader when it died — we are the leader now, so dispatch them to
+          // ourselves (see the matching re-delivery for non-leader tabs in
+          // `_onLeader`; the same at-least-once caveat applies).
+          this._callDeferreds.forEach(({ name, rest }, callNumber) => {
+            if (queued.has(callNumber)) return;
+            this._clearSentCall(callNumber);
+            this._onCall(this._id, callNumber, name, ...rest);
+          });
+          this.dispatchEvent(new Event('leadershipchange'));
+          this._postMessage(To.Others, 'onLeader', this._state);
+        }
         return keepLockPromise;
       }).catch(e => e !== 'Aborted' && Promise.reject(e) || false);
     } finally {
       this._isLeader = false;
+      this._isLeaderReady = false;
       this._api = null;
       this.dispatchEvent(new Event('leadershipchange'));
     }
@@ -166,6 +181,7 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
     return new Promise<R>(async (resolve, reject) => {
       const timeout = setTimeout(() => {
         this._callDeferreds.delete(callNumber);
+        this._queuedCalls.delete(callNumber);
         this._clearSentCall(callNumber);
         reject(new Error('Call timed out'));
       }, this._callTimeout);
@@ -209,6 +225,7 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
 
   close(): void {
     this.relinquishLeadership();
+    this._closeAbort.abort();
     this._isLeader = false;
     this._channel.close();
     this._channel.onmessage = null;
@@ -236,15 +253,15 @@ export class Tab<T = Record<string, any>> extends EventTarget implements Tab {
     const data = { to, name, rest };
     try {
       this._channel.postMessage(data);
-      if (this._isToMe(to, true)) {
-        this._onMessage(new MessageEvent('message', { data }));
-      }
     } catch (e) {
-      // If the channel is closed, create a new one and try again
-      if (e.name === 'InvalidStateError') {
-        this._createChannel();
-        this._postMessage(to, name, ...rest);
-      }
+      // Only a closed channel is recoverable: recreate it and retry once. Anything else (e.g. DataCloneError when a
+      // payload isn't structured-cloneable) must surface to the caller instead of silently dropping the message.
+      if (e.name !== 'InvalidStateError') throw e;
+      this._createChannel();
+      this._channel.postMessage(data);
+    }
+    if (this._isToMe(to, true)) {
+      this._onMessage(new MessageEvent('message', { data }));
     }
   }
 

--- a/tests/locks-fake.spec.ts
+++ b/tests/locks-fake.spec.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { installLocksFake } from './locks-fake';
+
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+let locks: ReturnType<typeof installLocksFake>;
+
+beforeEach(() => {
+  locks = installLocksFake();
+});
+
+describe('LocksFake', () => {
+  it('does not grant a queued waiter while a thief holds the stolen lock', async () => {
+    const ran: string[] = [];
+    let releaseThief!: () => void;
+
+    void locks.request('L', () => {
+      ran.push('holder');
+      return new Promise(() => {});
+    }).catch(() => {});
+    await wait(5);
+
+    void locks.request('L', () => {
+      ran.push('waiter');
+      return new Promise(() => {});
+    });
+    await wait(5);
+
+    void locks.request('L', { steal: true } as any, () => {
+      ran.push('thief');
+      return new Promise<void>(resolve => (releaseThief = resolve));
+    });
+    await wait(20);
+
+    // The evicted holder must not hand the lock to the waiter behind the thief's back.
+    expect(ran).toEqual(['holder', 'thief']);
+
+    releaseThief();
+    await wait(20);
+    expect(ran).toEqual(['holder', 'thief', 'waiter']);
+  });
+});

--- a/tests/locks-fake.ts
+++ b/tests/locks-fake.ts
@@ -66,6 +66,11 @@ export class LocksFake {
     });
   }
 
+  /** Requests still waiting in the queue for `name` (the current holder excluded). */
+  pendingCount(name: string): number {
+    return this.queues.get(name)?.length ?? 0;
+  }
+
   private grant(name: string, waiter: Pick<Waiter, 'cb' | 'resolve' | 'reject'>): void {
     let abort!: (reason: unknown) => void;
     const aborted = new Promise((_, rej) => (abort = rej));

--- a/tests/locks-fake.ts
+++ b/tests/locks-fake.ts
@@ -79,7 +79,10 @@ export class LocksFake {
     finished
       .then(waiter.resolve, waiter.reject)
       .finally(() => {
-        if (this.held.get(name)?.finished === finished) this.held.delete(name);
+        // A holder evicted by `steal` is no longer the current record and must not drive the queue: the thief holds
+        // the lock now, and its own release grants the next waiter.
+        if (this.held.get(name)?.finished !== finished) return;
+        this.held.delete(name);
         const next = this.queues.get(name)?.shift();
         if (next) this.grant(name, next);
       });

--- a/tests/tab.spec.ts
+++ b/tests/tab.spec.ts
@@ -211,6 +211,72 @@ describe('Tab leadership lifecycle', () => {
     tab.waitForLeadership(() => ({}));
     await wait(20);
 
-    expect(() => tab.setState({ fn: () => {} } as any)).toThrow();
+    const before = tab.getState();
+    let stateEvents = 0;
+    tab.addEventListener('state', () => stateEvents++);
+
+    expect(() => tab.setState({ fn: () => {} } as any)).toThrow(/could not be cloned|DataCloneError/);
+    // The broadcast must happen before the store, so a state no peer could receive is not left behind.
+    expect(tab.getState()).toBe(before);
+    expect(stateEvents).toBe(0);
+  });
+});
+
+describe('Tab postMessage failure paths', () => {
+  it('fails only the uncloneable queued call and still forwards the rest to the new leader', async () => {
+    // All three queue while there is no leader; the uncloneable one throws mid-sweep in `_onLeader`, and the
+    // queued call after it must still reach the new leader.
+    const spoke = makeTab({ callTimeout: 1500 });
+    const good1 = spoke.call('svc.work', 'a');
+    const bad = spoke.call('svc.work', () => {});
+    const badResult = bad.then(() => null, e => e);
+    const good2 = spoke.call('svc.work', 'c');
+    await wait(20);
+
+    const leader = makeTab();
+    leader.waitForLeadership(() => ({ svc: { work: async (x: string) => x } }));
+
+    await expect(good1).resolves.toBe('a');
+    await expect(good2).resolves.toBe('c');
+    expect((await badResult)?.message).toMatch(/could not be cloned|DataCloneError/);
+  });
+
+  it('rejects a call with an uncloneable argument immediately instead of at the timeout', async () => {
+    const leader = makeTab();
+    leader.waitForLeadership(() => ({ svc: { work: async (x: any) => x } }));
+    await wait(20);
+
+    const spoke = makeTab({ callTimeout: 5000 });
+    const started = Date.now();
+    await expect(spoke.call('svc.work', () => {})).rejects.toThrow(/could not be cloned|DataCloneError/);
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+});
+
+describe('Tab close', () => {
+  it('reports no leader and rejects calls once closed', async () => {
+    const leader = makeTab();
+    leader.waitForLeadership(() => ({ svc: { work: async () => 'ok' } }));
+    await wait(20);
+
+    const spoke = makeTab({ callTimeout: 5000 });
+    await expect(spoke.hasLeader()).resolves.toBe(true);
+
+    spoke.close();
+    await expect(spoke.hasLeader()).resolves.toBe(false);
+
+    const started = Date.now();
+    await expect(spoke.call('svc.work')).rejects.toThrow('Tab is closed');
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+
+  it('does not resurrect its channel when something posts after close', async () => {
+    const tab = makeTab();
+    tab.close();
+    const channel = (tab as any)._channel;
+
+    expect(() => tab.send('anyone there?')).not.toThrow();
+    expect((tab as any)._channel).toBe(channel);
+    expect(channel.onmessage).toBe(null);
   });
 });

--- a/tests/tab.spec.ts
+++ b/tests/tab.spec.ts
@@ -184,6 +184,28 @@ describe('Tab leadership lifecycle', () => {
     expect(locks.pendingCount(`tab-${name}`)).toBe(0);
   });
 
+
+  it('queues calls from two callers with the same call number without collision', async () => {
+    // The initializing leader's OWN first call and a spoke's first call are both
+    // callNumber 1 in their tabs. Keyed by number alone they collide in the leader's
+    // queue, and the loser is then skipped by the own-call re-delivery guard — a
+    // spoke-vs-spoke collision self-heals via onLeader re-delivery, but this one
+    // orphans until the call timeout.
+    let ready!: (api: any) => void;
+    const leader = makeTab({ callTimeout: 1500 });
+    void leader.waitForLeadership(() => new Promise(resolve => (ready = resolve)));
+    await wait(20);
+
+    const own = leader.call('svc.work', 'own');
+    const spoke = makeTab({ callTimeout: 1500 });
+    const foreign = spoke.call('svc.work', 'foreign');
+    await wait(50);
+
+    ready({ svc: { work: async (x: string) => x } });
+    await expect(own).resolves.toBe('own');
+    await expect(foreign).resolves.toBe('foreign');
+  });
+
   it('surfaces non-cloneable payload errors from setState instead of swallowing them', async () => {
     const tab = makeTab();
     tab.waitForLeadership(() => ({}));

--- a/tests/tab.spec.ts
+++ b/tests/tab.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { installLocksFake } from './locks-fake';
+import { installLocksFake, type LocksFake } from './locks-fake';
 import { Tab } from '../src/tab';
 
 /**
@@ -12,6 +12,7 @@ import { Tab } from '../src/tab';
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 let tabs: Tab[] = [];
+let locks: LocksFake;
 let names = 0;
 let name: string;
 
@@ -22,7 +23,7 @@ function makeTab(options?: { callTimeout?: number }): Tab {
 }
 
 beforeEach(() => {
-  installLocksFake();
+  locks = installLocksFake();
   name = `test-${++names}`;
 });
 
@@ -120,5 +121,74 @@ describe('Tab calls', () => {
     await wait(700); // > one resend interval
     monitor.close();
     expect(resends).toBe(0);
+  });
+});
+
+describe('Tab leadership lifecycle', () => {
+  it('does not broadcast onLeader when leadership is relinquished during the callback', async () => {
+    const monitor = new BroadcastChannel(`tab-${name}`);
+    let onLeaderPosts = 0;
+    monitor.onmessage = e => {
+      if (e.data?.name === 'onLeader') onLeaderPosts++;
+    };
+
+    const tab = makeTab();
+    await expect(tab.waitForLeadership(relinquish => relinquish())).resolves.toBe(true);
+    await wait(20);
+    monitor.close();
+    expect(onLeaderPosts).toBe(0);
+  });
+
+  it('queues calls that arrive while a re-elected leader is still initializing', async () => {
+    // Term 1 completes normally, then the same tab re-wins with a slow init;
+    // the ready flag from term 1 must not leak into term 2.
+    const tab = makeTab();
+    const term1 = tab.waitForLeadership(() => ({ svc: { work: async () => 'first' } }));
+    await wait(20);
+    tab.relinquishLeadership();
+    await term1;
+
+    let ready!: (api: any) => void;
+    void tab.waitForLeadership(() => new Promise(resolve => (ready = resolve)));
+    await wait(20);
+
+    const spoke = makeTab({ callTimeout: 1500 });
+    const pending = spoke.call('svc.work');
+    await wait(50);
+
+    ready({ svc: { work: async () => 'second' } });
+    await expect(pending).resolves.toBe('second');
+  });
+
+  it('drops a queued call once it times out instead of executing it on a later leader', async () => {
+    const spoke = makeTab({ callTimeout: 100 });
+    await expect(spoke.call('svc.work')).rejects.toThrow('Call timed out');
+
+    let executions = 0;
+    const leader = makeTab();
+    leader.waitForLeadership(() => ({ svc: { work: async () => executions++ } }));
+    await wait(50);
+    expect(executions).toBe(0);
+  });
+
+  it('cancels the has-leader watcher lock request on close', async () => {
+    const leader = makeTab();
+    leader.waitForLeadership(() => ({}));
+    await wait(20);
+
+    const spoke = makeTab();
+    await expect(spoke.hasLeader()).resolves.toBe(true);
+    expect(locks.pendingCount(`tab-${name}`)).toBe(1);
+
+    spoke.close();
+    expect(locks.pendingCount(`tab-${name}`)).toBe(0);
+  });
+
+  it('surfaces non-cloneable payload errors from setState instead of swallowing them', async () => {
+    const tab = makeTab();
+    tab.waitForLeadership(() => ({}));
+    await wait(20);
+
+    expect(() => tab.setState({ fn: () => {} } as any)).toThrow();
   });
 });


### PR DESCRIPTION
**TL;DR:** Six edge cases in tab coordination could make a tab show stale sync status, silently drop a cross-tab call, or leave phantom state behind after a tab closed. Each one could contribute to the "icon says synced when it isn't" class of bugs in Dabble. All are now fixed with tests that reproduce each failure.

## What

Found by the sync-v2 wedge audit; each fix has a test that fails on the unfixed source:

- **Relinquish during the leadership callback still broadcast `onLeader`** with this tab's stale state, posing it as fresh leader state (followers would re-latch a dead leader's `connected: true`). The post-callback block (ready flag, queued-call dispatch, broadcast) is now skipped when the callback already relinquished.
- **`_isLeaderReady` never reset between terms**: a re-elected tab looked ready while its `onLeadership` callback was still initializing, so incoming calls executed against a null api and rejected with `Invalid API method` instead of queuing. Reset in the `finally`.
- **A timed-out call stayed in `_queuedCalls`**, so a later leader executed it after the caller had already rejected. The timeout now removes it.
- **Queued calls were keyed by `callNumber` alone** — a per-tab counter, so the leader's queue collides across callers. Spoke-vs-spoke self-heals via `onLeader` re-delivery, but the leader's own queued call colliding with a spoke's is skipped by the re-delivery guard and orphans until the 30s call timeout. Keys are now `callerId:callNumber`.
- **`close()` left the has-leader watcher in the lock queue** — a closed tab kept a phantom position in the Web Locks queue until the next leadership change. The watcher now carries an AbortSignal aborted on close.
- **`_postMessage` swallowed every non-`InvalidStateError`**: a `DataCloneError` (non-cloneable state or message) vanished silently — fan-out just didn't happen. Only a closed channel is recoverable (recreated, retried once); anything else surfaces to the caller.

## Tests

Six new specs (each verified to fail before its fix), plus a `pendingCount` probe on the locks fake. 29 passing, tsc clean.